### PR TITLE
Habilitando o cors no endpoint cep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ dist
 # TernJS port file
 .tern-port
 
+.now
 
 # IDE
 .vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -3780,6 +3780,11 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
+    "micro-cors": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/micro-cors/-/micro-cors-0.1.1.tgz",
+      "integrity": "sha512-6WqIahA5sbQR1Gjexp1VuWGFDKbZZleJb/gy1khNGk18a6iN1FdTcr3Q8twaxkV5H94RjxIBjirYbWCehpMBFw=="
+    },
     "microevent.ts": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Vamos transformar o Brasil em uma API?",
   "dependencies": {
     "cep-promise": "^3.0.9",
+    "micro-cors": "^0.1.1",
     "next": "^9.2.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/pages/api/cep/v1/[cep].js
+++ b/pages/api/cep/v1/[cep].js
@@ -1,6 +1,25 @@
+import microCors from 'micro-cors';
 import cep from 'cep-promise';
 
-export default async function Cep(request, response) {
+// max-age especifica quanto tempo o browser deve manter o valor em cache, em segundos.
+// s-maxage é uma header lida pelo servidor proxy (neste caso, o Now da Zeit).
+//
+// Por que os valores abaixo?
+//
+// 1. O cache da Now é muito rápido e permite respostas em cerca de 10ms. O valor de
+//    um dia (86400 segundos) é suficiente para garantir performance e também que as
+//    respostas estejam relativamente sincronizadas caso o governo decida atualizar os CEPs.
+// 2. O cache da Now é invalidado toda vez que um novo deploy é feito, garantindo que
+//    todas as novas requisições sejam servidas pela implementação mais recente da API.
+// 3. Não há browser caching pois este tipo de API normalmente é utilizada uma vez só
+//    por um usuário. Se fizessemos caching, os valores ficariam lá guardados no browser
+//    sem necessidade, só ocupando espaço em disco. A história seria diferente se a API
+//    servisse fotos dos usuários, por exemplo. Além disso teríamos problemas com
+//    stale/out-of-date cache caso alterássemos a implementação da API.
+const CACHE_CONTROL_HEADER_VALUE = 'max-age=0, s-maxage=86400';
+const cors = microCors();
+
+async function Cep(request, response) {
     const requestedCep = request.query.cep;
 
     response.setHeader('Cache-Control', CACHE_CONTROL_HEADER_VALUE);
@@ -23,19 +42,4 @@ export default async function Cep(request, response) {
     }
 }
 
-// max-age especifica quanto tempo o browser deve manter o valor em cache, em segundos.
-// s-maxage é uma header lida pelo servidor proxy (neste caso, o Now da Zeit).
-//
-// Por que os valores abaixo?
-//
-// 1. O cache da Now é muito rápido e permite respostas em cerca de 10ms. O valor de
-//    um dia (86400 segundos) é suficiente para garantir performance e também que as
-//    respostas estejam relativamente sincronizadas caso o governo decida atualizar os CEPs.
-// 2. O cache da Now é invalidado toda vez que um novo deploy é feito, garantindo que
-//    todas as novas requisições sejam servidas pela implementação mais recente da API.
-// 3. Não há browser caching pois este tipo de API normalmente é utilizada uma vez só
-//    por um usuário. Se fizessemos caching, os valores ficariam lá guardados no browser
-//    sem necessidade, só ocupando espaço em disco. A história seria diferente se a API
-//    servisse fotos dos usuários, por exemplo. Além disso teríamos problemas com
-//    stale/out-of-date cache caso alterássemos a implementação da API.
-const CACHE_CONTROL_HEADER_VALUE = 'max-age=0, s-maxage=86400'
+export default cors(Cep);


### PR DESCRIPTION
## Descrição

- Foi feito a habilitação do cors para o ZEIT, o mesmo foi testado e foi com sucesso

![success](https://user-images.githubusercontent.com/22918282/74588918-853ead00-4fdf-11ea-8c10-2b1b17ece7d9.png)

Issue de referencia: https://github.com/filipedeschamps/BrasilAPI/issues/9

Discussões sobre o cors foi feito no PR: https://github.com/filipedeschamps/BrasilAPI/pull/20