### PR TITLE
feat: usar "stale-while-revalidate" para "[cep].js"

### DIFF
--- a/pages/api/cep/v1/[cep].js
+++ b/pages/api/cep/v1/[cep].js
@@ -2,7 +2,8 @@ import microCors from 'micro-cors';
 import cep from 'cep-promise';
 
 // max-age especifica quanto tempo o browser deve manter o valor em cache, em segundos.
-// s-maxage é uma header lida pelo servidor proxy (neste caso, o Now da Zeit).
+// s-maxage é uma header lida pelo servidor proxy (neste caso, o Now da ZEIT).
+// stale-while-revalidate indica que o conteúdo da cache pode ser servido como "stale" e revalidado no background
 //
 // Por que os valores abaixo?
 //

--- a/pages/api/cep/v1/[cep].js
+++ b/pages/api/cep/v1/[cep].js
@@ -16,7 +16,7 @@ import cep from 'cep-promise';
 //    sem necessidade, só ocupando espaço em disco. A história seria diferente se a API
 //    servisse fotos dos usuários, por exemplo. Além disso teríamos problemas com
 //    stale/out-of-date cache caso alterássemos a implementação da API.
-const CACHE_CONTROL_HEADER_VALUE = 'max-age=0, s-maxage=86400';
+const CACHE_CONTROL_HEADER_VALUE = 'max-age=0, s-maxage=86400, stale-while-revalidate, public';
 const cors = microCors();
 
 async function Cep(request, response) {


### PR DESCRIPTION
Docs aqui 👉 [LINK](https://zeit.co/docs/v2/network/caching#stale-while-revalidate).

Basicamente, podemos usar a cache do ZEIT Now de maneira um pouco mais inteligente. O comportamente aqui é quase o mesmo do que apenas usar "s-maxage" mas sempre vamos garantir respostas rápidas a partir do primeiro request. Servimos o que a "cache tem" enquanto a plataforma revalida a informação no background.

![Stale-while-revalidate](https://user-images.githubusercontent.com/7690649/75113867-438db200-5630-11ea-896f-d85f9cbd7b04.png)

Uso prático: https://zeit.co/blog/serverless-pre-rendering (depreciado em breve por iSSG https://notion-blog.now.sh/).