### PR TITLE
feat: adiciona código de erro semântico em casos de ceps mal formatados

### DIFF
--- a/pages/api/cep/v1/[cep].js
+++ b/pages/api/cep/v1/[cep].js
@@ -32,7 +32,6 @@ async function Cep(request, response) {
         response.json(cepResult);
 
     } catch (error) {
-
         if (error.name === 'CepPromiseError') {
             switch(error.type) {
                 case 'validation_error':

--- a/pages/api/cep/v1/[cep].js
+++ b/pages/api/cep/v1/[cep].js
@@ -35,10 +35,10 @@ async function Cep(request, response) {
 
         if (error.name === 'CepPromiseError') {
             switch(error.type) {
-                case "validation_error":
+                case 'validation_error':
                     response.status(400);
                     break;
-                case "service_error":
+                case 'service_error':
                     response.status(404);
                     break;
             }

--- a/pages/api/cep/v1/[cep].js
+++ b/pages/api/cep/v1/[cep].js
@@ -32,8 +32,17 @@ async function Cep(request, response) {
         response.json(cepResult);
 
     } catch (error) {
+
         if (error.name === 'CepPromiseError') {
-            response.status(404);
+            switch(error.type) {
+                case "validation_error":
+                    response.status(400);
+                    break;
+                case "service_error":
+                    response.status(404);
+                    break;
+            }
+
             response.json(error);
             return;
         }

--- a/pages/api/status/v1/index.js
+++ b/pages/api/status/v1/index.js
@@ -14,4 +14,4 @@ function Status(request, response) {
     });
 }
 
-export default cors(Status)
+export default cors(Status);

--- a/tests/cep-v1.test.js
+++ b/tests/cep-v1.test.js
@@ -44,14 +44,27 @@ describe('/cep/v1 (E2E)', () => {
     }
   });
 
-  test.skip('Utilizando um CEP inválido: 999999999999999', async () => {
-    // O endpoint /cep/v1 está retornando 404 independente
-    // do CEP não existir ou ele não ser válido. Podemos melhorar
-    // esse comportamento fazendo uma diferenciação no Status do
-    // response para quando for um type "validation_error" ou "service_error"
-
-    // Nesse caso aqui seria um "validation_error":
-    // "CEP deve conter exatamente 8 caracteres."
+  test('Utilizando um CEP inválido: 999999999999999', async () => {
+    expect.assertions(2);
+    const requestUrl = `${server.getUrl()}/api/cep/v1/999999999999999`;
+    
+    try {
+      await axios.get(requestUrl);
+      
+    } catch (error) {
+      const { response } = error;
+      
+      expect(response.status).toBe(400);
+      expect(response.data).toEqual({
+        name: "CepPromiseError",
+        message: "CEP deve conter exatamente 8 caracteres.",
+        type: "validation_error",
+        errors: [{
+          message: "CEP informado possui mais do que 8 caracteres.",
+          service: "cep_validation"
+        }]
+      });
+    }
   });
 
 });

--- a/tests/cep-v1.test.js
+++ b/tests/cep-v1.test.js
@@ -1,15 +1,15 @@
 const axios = require('axios');
 
-const createServer = require('./helpers/server.js')
+const createServer = require('./helpers/server.js');
 const server = createServer();
 
 beforeAll(async () => {
   await server.start();
-})
+});
 
 afterAll(async () => {
   await server.stop();
-})
+});
 
 describe('/cep/v1 (E2E)', () => {
   test('Utilizando um CEP válido: 05010000', async () => {

--- a/tests/cep-v1.test.js
+++ b/tests/cep-v1.test.js
@@ -56,12 +56,12 @@ describe('/cep/v1 (E2E)', () => {
       
       expect(response.status).toBe(400);
       expect(response.data).toEqual({
-        name: "CepPromiseError",
-        message: "CEP deve conter exatamente 8 caracteres.",
-        type: "validation_error",
+        name: 'CepPromiseError',
+        message: 'CEP deve conter exatamente 8 caracteres.',
+        type: 'validation_error',
         errors: [{
-          message: "CEP informado possui mais do que 8 caracteres.",
-          service: "cep_validation"
+          message: 'CEP informado possui mais do que 8 caracteres.',
+          service: 'cep_validation'
         }]
       });
     }

--- a/tests/cep-v1.test.js
+++ b/tests/cep-v1.test.js
@@ -25,14 +25,23 @@ describe('/cep/v1 (E2E)', () => {
     });
   });
 
-  test.skip('Utilizando um CEP inexistente: 00000000', async () => {
-    // O endpoint /cep/v1 está retornando 404 independente
-    // do CEP não existir ou ele não ser válido. Podemos melhorar
-    // esse comportamento fazendo uma diferenciação no Status do
-    // response para quando for um type "validation_error" ou "service_error"
-
-    // Nesse caso aqui seria um "service_error":
-    // "Todos os serviços de CEP retornaram erro."
+  test('Utilizando um CEP inexistente: 00000000', async () => {
+    expect.assertions(2);
+    const requestUrl = `${server.getUrl()}/api/cep/v1/00000000`;
+    
+    try {
+      await axios.get(requestUrl);
+      
+    } catch (error) {
+      const { response } = error;
+      
+      expect(response.status).toBe(404);
+      expect(response.data).toMatchObject({
+        name: 'CepPromiseError',
+        message: 'Todos os serviços de CEP retornaram erro.',
+        type: 'service_error'
+      });
+    }
   });
 
   test.skip('Utilizando um CEP inválido: 999999999999999', async () => {


### PR DESCRIPTION
Cobre o primeiro dos itens sugeridos pelo @filipedeschamps no pr #29, adicionando semântica aos status code em caso de erros no endpoint `/cep/v1`.

Um problema que eu notei é que a API do cep-promise aceita letras como valor. Mesmo sabendo que é extremamente improvável que alguém vá fazer uma requisição dessas, isso não é um caso que deveria ser tratado? Usar letras aqui gera um `"service_error"`, porque o cep-promise ainda envia as requisições e os serviços dizem que não encontraram nada. O correto seria, na minha visão, retornar também um `"validation_error"` pra esse caso.

Como a BrasilAPI apenas captura as exceções lançadas pelo cep-promise e não faz validação, eu achei melhor não mexer nisso aqui agora. Acho que a mudança, se ela for mesmo absolutamente necessária, teria que ser feita direto na lib